### PR TITLE
list project-type, http redirects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ lint:
 lint-report:
 	pylint --reports=n zanata zanataclient
 
+flake8:
+	flake8 --ignore=E501,F403,W601,F841,F401,E711,E712 zanataclient test
+
 test:
 	(cd test; python test_all.py)
 
@@ -40,4 +43,4 @@ help:
 	@echo "For help on zanata itself, use 'make run'"
 
 
-.PHONY: all sdist install uninstall clean run lint lint-report test
+.PHONY: all sdist install uninstall clean run lint lint-report flake8 test

--- a/zanataclient/zanatacmd.py
+++ b/zanataclient/zanatacmd.py
@@ -190,15 +190,17 @@ class ZanataCommand:
         projects = self.zanata_resource.projects.list()
 
         if not projects:
-            self.log.error("There is no projects on the server or the server not working")
+            # As we are catching exceptions related to reaching server,
+            # we may be certain that there is NO projects created.
+            self.log.error("There is no projects on the server.")
             sys.exit(1)
+
         for project in projects:
             print ("\nProject ID:          %s") % project.id
             print ("Project Name:        %s") % project.name
-            # print ("Project Type:        %s") % project.type
-            print ("Project Links:       %s\n") % [{'href': link.href, 'type': link.type, 'rel': link.rel} for link in project.links]
-
-        return projects
+            if project.defaultType.strip():
+                print ("Project Type:        %s") % project.defaultType
+            print ("Project Links:       %s") % [{'href': link.href, 'type': link.type, 'rel': link.rel} for link in project.links]
 
     def project_info(self, project_id):
         """
@@ -206,10 +208,10 @@ class ZanataCommand:
         """
         try:
             p = self.zanata_resource.projects.get(project_id)
-            # pylint: disable=E1101
             print ("Project ID:          %s") % p.id
             print ("Project Name:        %s") % p.name
-            # print ("Project Type:        %s") % p.type
+            if p.defaultType.strip():
+                print ("Project Type:        %s") % p.defaultType
             print ("Project Description: %s") % p.description
         except NoSuchProjectException, e:
             self.log.error(str(e))

--- a/zanataclient/zanatalib/glossaryservice.py
+++ b/zanataclient/zanatalib/glossaryservice.py
@@ -42,8 +42,6 @@ class GlossaryService(Service):
 
         headers['Accept'] = 'application/vnd.zanata.glossary+json'
 
-        res, content = self.restclient.request_put('/seam/resource/restv1/glossary', args=resources, headers=headers)
-
         res, content = self.restclient.request_put('/seam/resource/restv1/glossary',
                                                    args=resources,
                                                    headers=headers)

--- a/zanataclient/zanatalib/rest/client.py
+++ b/zanataclient/zanatalib/rest/client.py
@@ -102,8 +102,14 @@ class RestClient(object):
             response, content = self.http_client.request(resource, method.upper(), body, headers=headers)
             if response.previous is not None:
                 if response.previous.status == 301 or response.previous.status == 302:
-                    new_url = response.previous['-x-permanent-redirect-url'][:-len(resource)]
-                    print "HTTP redirect: redirect to %s, please update the server URL to new URL" % new_url
+                    try:
+                        new_url = response.previous['-x-permanent-redirect-url'][:-len(resource)]
+                    except:
+                        new_url = response.previous['location']
+                    if new_url:
+                        print "\nRedirecting to: %s" % '{uri.scheme}://{uri.netloc}/'.format(uri=urlparse.urlparse(new_url))
+                        print "HTTP Redirect: Please update the Server URL."
+                        response, content = self.http_client.request(new_url, method.upper(), body, headers=headers)
             return (response, content.decode("UTF-8"))
         except httplib2.ServerNotFoundError, e:
             print "error: %s, Maybe the Zanata server is down?" % e


### PR DESCRIPTION
1. In listing of projects, project-type may be shown if exists.
2. users pointing to http may be taken to https automatically.
   - This caters to `http://translate.zanata.org/zanata` 
